### PR TITLE
Informed ThumbnailService about updating, deletion of image

### DIFF
--- a/HiP-Achievements/HiP-Achievements.csproj
+++ b/HiP-Achievements/HiP-Achievements.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="EventStore.ClientAPI.NetCore" Version="4.0.2-rc" />
     <PackageReference Include="HiP-DataStore.Sdk" Version="1.0.1-develop" />
+    <PackageReference Include="HiP-ThumbnailService.Sdk" Version="1.0.0-develop" />
     <PackageReference Include="HiP-WebserviceLib" Version="2.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />

--- a/HiP-Achievements/Utility/EndpointConfig.cs
+++ b/HiP-Achievements/Utility/EndpointConfig.cs
@@ -31,5 +31,10 @@
         /// Endpoint of the Datastore
         /// </summary>
         public string DataStoreHost { get; set; }
+
+        /// <summary>
+        /// Endpoint of the ThumbnailService
+        /// </summary>
+        public string ThumbnailServiceHost { get; set; }
     }
 }

--- a/HiP-Achievements/Utility/UrlHelper.cs
+++ b/HiP-Achievements/Utility/UrlHelper.cs
@@ -1,0 +1,16 @@
+﻿namespace PaderbornUniversity.SILab.Hip.Achievements.Utility
+{
+    public static class UrlHelper
+    {
+        public static string GenerateImageUrl(string thumnailUrlPattern, int id)
+        {
+            if (!string.IsNullOrWhiteSpace(thumnailUrlPattern))
+            {
+                // Generate thumbnail URL (if a thumbnail URL pattern is configured)
+                return string.Format(thumnailUrlPattern, id);
+            }
+
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
I noticed that the ThumbnailService is not informed about updates and the deletion of images. This PR uses the NuGet-Package and informs the ThumbnailService about these changes