### PR TITLE
Fixed deletion of Achievements

### DIFF
--- a/HiP-Achievements/Controllers/AchievementsController.cs
+++ b/HiP-Achievements/Controllers/AchievementsController.cs
@@ -5,7 +5,6 @@ using PaderbornUniversity.SILab.Hip.Achievements.Core.ReadModel;
 using PaderbornUniversity.SILab.Hip.Achievements.Core.WriteModel;
 using PaderbornUniversity.SILab.Hip.Achievements.Model;
 using PaderbornUniversity.SILab.Hip.Achievements.Model.Entity;
-using PaderbornUniversity.SILab.Hip.Achievements.Model.Events;
 using PaderbornUniversity.SILab.Hip.Achievements.Model.Rest;
 using PaderbornUniversity.SILab.Hip.Achievements.Utility;
 using PaderbornUniversity.SILab.Hip.DataStore;

--- a/HiP-Achievements/Controllers/AchievementsController.cs
+++ b/HiP-Achievements/Controllers/AchievementsController.cs
@@ -150,18 +150,13 @@ namespace PaderbornUniversity.SILab.Hip.Achievements.Controllers
 
             if (!string.IsNullOrEmpty(achievement.Filename))
             {
-                System.IO.File.Delete(achievement.Filename);
+                if (System.IO.File.Exists(achievement.Filename))
+                    System.IO.File.Delete(achievement.Filename);
                 await _thumbnailService.TryClearThumbnailCacheAsync(id);
             }
 
-            var ev = new AchievementDeleted()
-            {
-                Id = id,
-                UserId = User.Identity.GetUserIdentity(),
-                Timestamp = DateTime.Now
-            };
-
-            await _eventStore.AppendEventAsync(ev);
+            //we use the BaseResourceType here
+            await EntityManager.DeleteEntityAsync(_eventStore, ResourceTypes.Achievement, id, User.Identity.GetUserIdentity());
             return NoContent();
         }
 

--- a/HiP-Achievements/Controllers/ActionControllers/ExhibitVisitedController.cs
+++ b/HiP-Achievements/Controllers/ActionControllers/ExhibitVisitedController.cs
@@ -29,7 +29,6 @@ namespace PaderbornUniversity.SILab.Hip.Achievements.Controllers.ActionControlle
 
         /// <summary>
         /// Posts multiple ExhibitVisistedActions
-
         /// </summary>
         [HttpPost("Many")]
         [ProducesResponseType(typeof(int), 201)]

--- a/HiP-Achievements/Migrations/Migration3FixDeleteAchievement.cs
+++ b/HiP-Achievements/Migrations/Migration3FixDeleteAchievement.cs
@@ -1,0 +1,39 @@
+﻿using PaderbornUniversity.SILab.Hip.Achievements.Model.Events;
+using PaderbornUniversity.SILab.Hip.EventSourcing.Events;
+using PaderbornUniversity.SILab.Hip.EventSourcing.Migrations;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.Achievements.Migrations
+{
+    [StreamMigration(from: 2, to: 3)]
+    public class Migration3FixDeleteAchievement : IStreamMigration
+    {
+        private List<int> _deletedIds = new List<int>();
+
+        public async Task MigrateAsync(IStreamMigrationArgs e)
+        {
+            var events = e.GetExistingEvents();
+            while (await events.MoveNextAsync())
+            {
+                switch (events.Current)
+                {
+                    case AchievementDeleted ev:
+                        if (!_deletedIds.Contains(ev.Id))
+                        {
+                            e.AppendEvent(new DeletedEvent(ev.GetEntityType().Name, ev.Id, ev.UserId)
+                            {
+                                Timestamp = ev.Timestamp
+                            });
+                            _deletedIds.Add(ev.Id);
+                        }
+                        break;
+
+                    default:
+                        e.AppendEvent(events.Current);
+                        break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
During the migration to the new architecture I forgot to modify the deletion of achievements. Therefore deleting an achievement just created an event that isn't used anymore. This PR fixes this behaviour and also fixes the event stream with Migration 3