### PR TITLE
API call for getting info about exhibit visitors

### DIFF
--- a/HiP-Achievements.Sdk/HiP-Achievements.Sdk.csproj
+++ b/HiP-Achievements.Sdk/HiP-Achievements.Sdk.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>PaderbornUniversity.SILab.Hip.Achievements</RootNamespace>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
     <NoWarn>1701;1702;1705;1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/HiP-Achievements.TypeScript/package/package.json
+++ b/HiP-Achievements.TypeScript/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hip-achievements",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "TypeScript client for Achievements",
   "repository": {
     "type": "git",

--- a/HiP-Achievements/Controllers/ActionControllers/ExhibitVisitedController.cs
+++ b/HiP-Achievements/Controllers/ActionControllers/ExhibitVisitedController.cs
@@ -73,13 +73,11 @@ namespace PaderbornUniversity.SILab.Hip.Achievements.Controllers.ActionControlle
         /// <summary>
         /// Get all Actions of Exhibit Visited type of all users by exhibit ID
         /// </summary>
-        /// <param name="exhibitId"></param>
-        /// <param name="Timestamp"></param>
         /// <returns></returns>
         [HttpGet("All/{exhibitId}")]
         [ProducesResponseType(typeof(AllItemsResult<ActionResult>), 200)]
         [ProducesResponseType(400)]
-        public IActionResult GetAll(int exhibitId, DateTimeOffset? Timestamp = null)
+        public IActionResult GetAll(int exhibitId, DateTimeOffset? timestamp = null)
         {
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
@@ -94,7 +92,7 @@ namespace PaderbornUniversity.SILab.Hip.Achievements.Controllers.ActionControlle
             var query = _db.Database.GetCollection<Action>(ResourceTypes.Action.Name).AsQueryable();
 
             var result = query.Where(x => (x.EntityId == exhibitId))
-                              .FilterByTimestamp(Timestamp).ToList()
+                              .FilterByTimestamp(timestamp).ToList()
                               .Where(x => (x.TypeName == "ExhibitVisited"))
                               .Select(x => x.CreateActionResult())
                               .ToList();

--- a/HiP-Achievements/Utility/UserPermissions.cs
+++ b/HiP-Achievements/Utility/UserPermissions.cs
@@ -51,6 +51,17 @@ namespace PaderbornUniversity.SILab.Hip.Achievements.Utility
             return CheckRoles(identity);
         }
 
+        /// <summary>
+        /// Only Supervisor and Administrator can get all information about Users Actions
+        /// </summary>
+        /// <param name="identity"></param>
+        /// <returns></returns>
+        public static bool IsAllowedToGetAllActions(IIdentity identity)
+        {
+            return CheckRoles(identity);
+        }
+
+
         public static bool IsAllowedToCreateImage(IIdentity identity, string ownerId)
         {
             bool isOwner = ownerId == identity.GetUserIdentity();


### PR DESCRIPTION
Added new api call GET: /Actions/ExhibitVisited/All/{exhibitId} which will return the users and time when they visited this exhibit (Restricted to role administrator and supervisor).
Fixed Bug with API Call POST: /Actions/ExhibitVisited/Many.